### PR TITLE
Add a default namespace option

### DIFF
--- a/charts/minibroker/templates/broker.yaml
+++ b/charts/minibroker/templates/broker.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.deployServiceCatalog }}
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ClusterServiceBroker
 metadata:
@@ -9,3 +10,4 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   url: http://minibroker-minibroker.minibroker.svc.cluster.local
+{{ end }}

--- a/charts/minibroker/templates/deployment.yaml
+++ b/charts/minibroker/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
         - -helmUrl
         - "{{ .Values.helmRepoUrl }}"
         {{- end }}
+        {{- if .Values.defaultNamespace }}
+        - -defaultNamespace
+        - "{{ .Values.defaultNamespace }}"
+        {{- end }}
         - --port
         - "8080"
         {{- if .Values.tls.cert }}

--- a/charts/minibroker/values.yaml
+++ b/charts/minibroker/values.yaml
@@ -12,3 +12,5 @@ tls:
   key:
 
 serviceCatalogEnabledOnly: true
+
+deployServiceCatalog: true

--- a/cmd/minibroker/main.go
+++ b/cmd/minibroker/main.go
@@ -40,6 +40,8 @@ func init() {
 		"The path to the catalog")
 	flag.StringVar(&options.HelmRepoUrl, "helmUrl", "",
 		"The url to the helm repo")
+	flag.StringVar(&options.DefaultNamespace, "defaultNamespace", "",
+		"The default namespace for brokers when the request doesn't specify")
 	flag.Parse()
 }
 

--- a/pkg/broker/options.go
+++ b/pkg/broker/options.go
@@ -3,5 +3,6 @@ package broker
 type Options struct {
 	HelmRepoUrl               string
 	CatalogPath               string
+	DefaultNamespace          string
 	ServiceCatalogEnabledOnly bool
 }


### PR DESCRIPTION
Cloud Foundry doesn't provide a namespace in its request, so a default
namespace can be used instead.