### PR TITLE
charts/minibroker: set to SUSE-sensible defaults

### DIFF
--- a/charts/minibroker/values.yaml
+++ b/charts/minibroker/values.yaml
@@ -1,6 +1,6 @@
 # Default values for the minibroker
 # Image to use
-image: osbkit/minibroker:latest
+image: splatform/minibroker:latest
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: IfNotPresent
 deploymentPolicy: RollingUpdate
@@ -13,4 +13,4 @@ tls:
 
 serviceCatalogEnabledOnly: true
 
-deployServiceCatalog: true
+deployServiceCatalog: false


### PR DESCRIPTION
This sets the default image to ours, and to turn off the service catalog stuff that isn't relevant for us.

Image kept at `latest` as there is currently no sensible alternative (we haven't been tagging our images, and there isn't a good version number to use).