### PR TITLE
Bisingh/suse registry

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -32,7 +32,7 @@ RUN curl -sLO https://github.com/golang/dep/releases/download/$DEP_VERSION/dep-l
     mv ./dep-linux-amd64 /usr/local/bin/dep
 
 # Install the azure client, used to publish svcat binaries
-ENV AZCLI_VERSION=v0.1.2
+ENV AZCLI_VERSION=v0.3.1
 RUN curl -sLo /usr/local/bin/az https://github.com/carolynvs/az-cli/releases/download/$AZCLI_VERSION/az-linux-amd64 && \
 chmod +x /usr/local/bin/az
 

--- a/charts/minibroker/Chart.yaml
+++ b/charts/minibroker/Chart.yaml
@@ -1,3 +1,3 @@
 name: minibroker
 description: A minibroker for your minikube
-version: 0.2.1
+version: 0.2.2

--- a/charts/minibroker/Chart.yaml
+++ b/charts/minibroker/Chart.yaml
@@ -1,3 +1,3 @@
 name: minibroker
 description: A minibroker for your minikube
-version: 0.2.0
+version: 0.2.1

--- a/charts/minibroker/templates/broker.yaml
+++ b/charts/minibroker/templates/broker.yaml
@@ -8,4 +8,4 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  url: http://minibroker-minibroker.minibroker.svc.cluster.local
+  url: http://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/hack/create-cluster.sh
+++ b/hack/create-cluster.sh
@@ -6,7 +6,7 @@ minikube addons enable heapster
 
 if [[ "$(minikube status)" != *"Running"* ]]; then
     minikube start --vm-driver=virtualbox \
-    --kubernetes-version=v1.9.6 \
+    --kubernetes-version=v1.11.3 \
     --bootstrapper=kubeadm
 fi
 


### PR DESCRIPTION
**DO NOT MERGE**

This PR specifies SUSE Registry to be used for container images instead of DockerHub.

**Note:** This PR should only be merged once:

1. This PR is merged and tested: https://github.com/SUSE/cloudfoundry/pull/102
2. @thardeck releases container images to registry.suse.com

Details: https://trello.com/c/3oq0Yimf/919-host-minibroker-images-on-registrysusecom