### PR TITLE
Don't bind to cluster-admin role if defaultNamespace is defined

### DIFF
--- a/charts/minibroker/templates/_helpers.tpl
+++ b/charts/minibroker/templates/_helpers.tpl
@@ -4,6 +4,17 @@
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "minibroker.fullname" -}}
 {{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Define the standard labels that will be applied to all objects in this chart.
+*/}}
+{{- define "minibroker.labels" }}
+  labels:
+    app: {{ template "minibroker.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}

--- a/charts/minibroker/templates/broker.yaml
+++ b/charts/minibroker/templates/broker.yaml
@@ -3,11 +3,7 @@ apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ClusterServiceBroker
 metadata:
   name: minibroker
-  labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  {{- template "minibroker.labels" . }}
 spec:
-  url: http://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  url: http://{{ template "minibroker.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 {{ end }}

--- a/charts/minibroker/templates/deployment.yaml
+++ b/charts/minibroker/templates/deployment.yaml
@@ -1,26 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
-  labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  name: {{ template "minibroker.fullname" . }}
+  {{- template "minibroker.labels" . }}
 spec:
   replicas: 1
   strategy:
     type: {{ .Values.deploymentStrategy }}
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}
+      app: {{ template "minibroker.fullname" . }}
   template:
     metadata:
-      labels:
-        app: {{ template "fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        release: "{{ .Release.Name }}"
-        heritage: "{{ .Release.Service }}"
+      {{- include "minibroker.labels" . | nindent 6 }}
     spec:
       serviceAccountName: minibroker
       containers:

--- a/charts/minibroker/templates/rbac.yaml
+++ b/charts/minibroker/templates/rbac.yaml
@@ -1,8 +1,85 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: minibroker
   {{- template "minibroker.labels" . }}
+
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+
+# If a "defaultNamespace" has been defined, then only grant access to the
+# release namespace itself (for storing data in a configmap), and to the
+# defaultNamespace (to maintain the service instances).
+{{- if .Values.defaultNamespace }}
+
+# If we install the services into the release namespace, then the namespace
+# already exists, and the configmap role binding becomes redundant because
+# we'll grant full access to the defaultNamespace.
+{{- if ne .Release.Namespace .Values.defaultNamespace }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.defaultNamespace }}
+  {{- template "minibroker.labels" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: minibroker-configmap
+  {{- template "minibroker.labels" . }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs:     ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: minibroker-configmap
+  {{- template "minibroker.labels" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: minibroker-configmap
+subjects:
+- kind: ServiceAccount
+  name: minibroker
+  namespace: {{ .Release.Namespace }}
+{{- end }}{{/* if ne .Release.Namespace .Values.defaultNamespace */}}
+
+# Provide full access to the defaultNamespace to the release namespace
+# service account.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: minibroker-services
+  namespace: {{ .Values.defaultNamespace }}
+  {{- template "minibroker.labels" . }}
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs:     ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: minibroker-services
+  namespace: {{ .Values.defaultNamespace }}
+  {{- template "minibroker.labels" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: minibroker-services
+subjects:
+- kind: ServiceAccount
+  name: minibroker
+  namespace: {{ .Release.Namespace }}
+
+# If a defaultNamespace has not been defined, then run everything
+# using cluster-admin permissions; we now own this place! :)
+{{- else }}{{/* if .Values.defaultNamespace */}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -17,3 +94,6 @@ subjects:
 - kind: ServiceAccount
   name: minibroker
   namespace: {{ .Release.Namespace }}
+{{- end }}{{/* if .Values.defaultNamespace */}}
+
+{{- end }}{{/* if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" */}}

--- a/charts/minibroker/templates/rbac.yaml
+++ b/charts/minibroker/templates/rbac.yaml
@@ -2,21 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: minibroker
-  labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  {{- template "minibroker.labels" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: minibroker
-  labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  {{- template "minibroker.labels" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/minibroker/templates/service.yaml
+++ b/charts/minibroker/templates/service.yaml
@@ -1,15 +1,11 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}
-  labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  name: {{ template "minibroker.fullname" . }}
+  {{- template "minibroker.labels" . }}
 spec:
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "minibroker.fullname" . }}
   ports:
   - protocol: TCP
     port: 80


### PR DESCRIPTION
minibroker is configured with a `defaultNamespace` when being used as a Cloud Foundry service broker because CF does not pass along a namespace to the broker.  That means all services will be instantiated inside the `defaultNamespace`.

There are 2 configuration choices: the `defaultNamespace` is identical to the release namespace, or it is separate.

This patch will create the `defaultNamespace` (if specified) and create a role providing unlimited access to it, which will be bound to the `minibroker` service account in the release namespace.

It will also bind a role granting all operations on configmaps inside the release namespace to the `minibroker` service account because minibroker creates and updates a configmap to track configuration information.

In case the `defaultNamespace` is identical to the release namespace, the namespace is already created by helm. Also the configmap role is then redundant with the unlimited access provided to the `defaultNamespace` and therefore omitted.

If the `defaultNamespace` is not defined, the chart will continue to create a cluster role binding to the `cluster-admin` role, just as before.

# Testing

For testing I've deployed the updated chart using the instructions from the documentation at [CAP minibroker deployment](https://www.suse.com/documentation/cloud-application-platform-1/book_cap_guides/data/sec_cap_minibroker-deployment.html).

For testing on Vagrant I had to use the internal chart repo from CI to get a working redis chart:

```
helm install output/minibroker --namespace minibroker --name minibroker --set defaultNamespace=minibroker --set helmRepoUrl=https://minibroker-helm-charts.s3.amazonaws.com/kubernetes-charts/
```

I've tested both `defaultNamespace=minibroker` and `defaultNamespace=minibroker-service`.