### PR TITLE
Using SUSE registry for tiller image

### DIFF
--- a/charts/minibroker/templates/deployment.yaml
+++ b/charts/minibroker/templates/deployment.yaml
@@ -56,5 +56,3 @@ spec:
           value: {{ .Release.Namespace }}
         - name: TILLER_HISTORY_MAX
           value: "1"
-        command: ["/tiller"]
-        args: ["--listen=localhost:44134"]

--- a/charts/minibroker/templates/deployment.yaml
+++ b/charts/minibroker/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
         ports:
         - containerPort: 8080
       - name: tiller
-        image: "gcr.io/kubernetes-helm/tiller:v2.13.1"
+        image: "{{ .Values.tiller.registry.hostname }}/{{ .Values.tiller.organization }}/{{ .Values.tiller.image }}:{{ .Values.tiller.version }}"
         imagePullPolicy: IfNotPresent
         env:
         - name: TILLER_NAMESPACE

--- a/charts/minibroker/templates/deployment.yaml
+++ b/charts/minibroker/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
         ports:
         - containerPort: 8080
       - name: tiller
-        image: "{{ .Values.tiller.registry.hostname }}/{{ .Values.tiller.organization }}/{{ .Values.tiller.image }}:{{ .Values.tiller.version }}"
+        image: "{{ .Values.kube.registry.hostname }}/{{ .Values.kube.organization }}/helm-tiller:2.14.2"
         imagePullPolicy: IfNotPresent
         env:
         - name: TILLER_NAMESPACE

--- a/charts/minibroker/values.yaml
+++ b/charts/minibroker/values.yaml
@@ -18,18 +18,9 @@ serviceCatalogEnabledOnly: true
 
 deployServiceCatalog: false
 
-tiller:
-  version: 2.14.2
-  image: helm-tiller
-  registry: 
+kube:
+  registry:
     hostname: registry.suse.com
     username: ""
     password: ""
   organization: cap
-
-kube:
-  registry:
-    hostname: index.docker.io
-    username: ""
-    password: ""
-  organization: splatform

--- a/charts/minibroker/values.yaml
+++ b/charts/minibroker/values.yaml
@@ -18,6 +18,15 @@ serviceCatalogEnabledOnly: true
 
 deployServiceCatalog: false
 
+tiller:
+  version: 2.14.2
+  image: helm-tiller
+  registry: 
+    hostname: registry.suse.com
+    username: ""
+    password: ""
+  organization: cap
+
 kube:
   registry:
     hostname: index.docker.io


### PR DESCRIPTION
## Description

This PR add following changes;
- Using `SUSE` registry for tiller image instead of `GCR`.
- Remove custom command in tiller image to fallback on `Entrypoint`.